### PR TITLE
Fix error, when remote network is not in DNS

### DIFF
--- a/task/WinRmFileCopy.ps1
+++ b/task/WinRmFileCopy.ps1
@@ -17,7 +17,7 @@ function Resolve-HostNameOrAddress
     { 
         if ([bool]($ComputerName -as [ipaddress]))
         {
-            $host1 = [System.Net.Dns]::GetHostEntry($ComputerName)
+            return $ComputerName
         }
         else
         {


### PR DESCRIPTION
[System.Net.Dns]::GetHostEntry("10.0.0.1")
Exception calling "GetHostEntry" with "1" argument(s): "No such host is known"
At line:1 char:1
+ [System.Net.Dns]::GetHostEntry("10.0.0.1")
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : SocketException